### PR TITLE
Fix_mssing-category-tags-in-search-results

### DIFF
--- a/lib/mongoDBPipelines.js
+++ b/lib/mongoDBPipelines.js
@@ -2,7 +2,7 @@
 
 // Pipline for fulltext serach after submit
 
-export const createSearchPipline = (searchTerm) => {
+export const createSearchPipeline = (searchTerm) => {
   return [
     {
       $search: {

--- a/lib/mongoDBPipelines.js
+++ b/lib/mongoDBPipelines.js
@@ -26,6 +26,20 @@ export const createSearchPipeline = (searchTerm) => {
         textScore: { $meta: "searchScore" },
       },
     },
+    {
+      $lookup: {
+        from: "categories",
+        localField: "category",
+        foreignField: "_id",
+        as: "category",
+      },
+    },
+    {
+      $unwind: {
+        path: "$category",
+        preserveNullAndEmptyArrays: true,
+      },
+    },
   ];
 };
 

--- a/pages/api/search/[searchTerm]/index.js
+++ b/pages/api/search/[searchTerm]/index.js
@@ -1,7 +1,7 @@
 import dbConnect from "@/db/connect";
 import Event from "@/db/models/Event";
 import {
-  createSearchPipline,
+  createSearchPipeline,
   createAutocompletePipeline,
 } from "@/lib/mongoDBPipelines";
 
@@ -16,7 +16,7 @@ export default async function handler(request, response) {
   // Check if query is for search or for autocomplete and set pipeline function accordingly
 
   const pipeline = isSubmitted
-    ? createSearchPipline
+    ? createSearchPipeline
     : createAutocompletePipeline;
 
   if (request.method === "GET") {


### PR DESCRIPTION
Implement Category Population in Event Search Pipeline

Modified the createSearchPipeline function to include a $lookup stage. This change allows the pipeline to join each event document with its corresponding category document based on the category field, which links to the Category collection via ObjectId.
Added a $unwind stage following the $lookup. This is necessary to deconstruct the array of category documents into individual documents, ensuring that each event is associated with its respective category data.